### PR TITLE
Remove romeo_dcm_control from *.ignored files

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ These packages were released:
 
 These packages were explicitly ignored:
 - `romeo_dcm_bringup`
-- `romeo_dcm_control`
 - `romeo_dcm_driver`
 - `romeo_dcm_msgs`
 

--- a/indigo.ignored
+++ b/indigo.ignored
@@ -1,4 +1,3 @@
 romeo_dcm_bringup
-romeo_dcm_control
 romeo_dcm_driver
 romeo_dcm_msgs

--- a/jade.ignored
+++ b/jade.ignored
@@ -1,4 +1,3 @@
 romeo_dcm_bringup
-romeo_dcm_control
 romeo_dcm_driver
 romeo_dcm_msgs

--- a/kinetic.ignored
+++ b/kinetic.ignored
@@ -1,4 +1,3 @@
 romeo_dcm_bringup
-romeo_dcm_control
 romeo_dcm_driver
 romeo_dcm_msgs


### PR DESCRIPTION
Let's remove romeo_dcm_control from the "ignored" list, it does not depend on Naoqi and it is needed for romeo_gazebo_plugin
