### PR TITLE
restore indigo and jade ignored files

### DIFF
--- a/indigo.ignored
+++ b/indigo.ignored
@@ -1,0 +1,4 @@
+romeo_dcm_bringup
+romeo_dcm_control
+romeo_dcm_driver
+romeo_dcm_msgs

--- a/jade.ignored
+++ b/jade.ignored
@@ -1,0 +1,4 @@
+romeo_dcm_bringup
+romeo_dcm_control
+romeo_dcm_driver
+romeo_dcm_msgs


### PR DESCRIPTION
#2 broke the release process for all distros having any romeo_dcm* released before. Readding the ignored files for indigo and jade should fix it